### PR TITLE
New setBrightness function for SH1106 to prevent flickering caused by…

### DIFF
--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -143,6 +143,29 @@ class SH1106Wire : public OLEDDisplay {
       #endif
     }
 
+    //unlike SSD1306, SH1106 goes black when VCOM is adjusted, so we'll override setBrightness so we can leave VCOM alone during brightness adjustment.
+    void setBrightness(uint8_t brightness) override
+    {
+    	sendCommand(SETPRECHARGE); //0xD9
+    	sendCommand(brightness / 19 + 242); // empirically determined. brightness / 18 + 241 goes a bit darker but is too contrasty without VCOM adjustment
+
+    	uint8_t contrast=brightness;
+
+    	if(brightness<19)
+    	{
+    	  // Prevent jump between brightness 19 and 18 by multiplying contrast by 3.5 (56 / 16)
+    		contrast = (((uint16_t) brightness * 56)>>4);
+    	}
+    	else if(brightness<38)
+    	{
+    		// Prevent jump between brightness 38 and 37 by multiplying contrast by 1.5 (24 / 16)
+    		contrast = (((uint16_t) brightness * 24)>>4);
+    	}
+
+    	sendCommand(SETCONTRAST);
+    	sendCommand(contrast); // 0-255
+    };
+
   private:
 	int getBufferOffset(void) {
 		return 0;


### PR DESCRIPTION
… the SSD1306 code setting VCOM, which causes SH1106 to mute the backlight every time you change the brightness.

Your virtualizing of the OLEDDisplay methods came in handy as it allowed making this change without affecting anything else.

I spent some time getting the magic numbers right for the SH1106 display to seamlessly adjust brightness, and tested with four different specimen of the SH1106 based 1.3" black and white I2C OLED commonly available on Aliexpress.